### PR TITLE
Fixing Redis warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gcra (1.2.0)
+    gcra (1.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,21 +6,21 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
-    redis (3.3.3)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    diff-lcs (1.5.0)
+    redis (3.3.5)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
 
 PLATFORMS
   ruby
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec (~> 3.5)
 
 BUNDLED WITH
-   1.17.3
+   2.3.7

--- a/lib/gcra/redis_store.rb
+++ b/lib/gcra/redis_store.rb
@@ -30,9 +30,9 @@ module GCRA
     # Returns the value of the key or nil, if it isn't in the store.
     # Also returns the time from the Redis server, with microsecond precision.
     def get_with_time(key)
-      time_response, value = @redis.pipelined do
-        @redis.time # returns tuple (seconds since epoch, microseconds)
-        @redis.get(@key_prefix + key)
+      time_response, value = @redis.pipelined do |pipelined|
+        pipelined.time # returns tuple (seconds since epoch, microseconds)
+        pipelined.get(@key_prefix + key)
       end
       # Convert tuple to nanoseconds
       time = (time_response[0] * 1_000_000 + time_response[1]) * 1_000

--- a/lib/gcra/version.rb
+++ b/lib/gcra/version.rb
@@ -1,3 +1,3 @@
 module GCRA
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.3.0'.freeze
 end


### PR DESCRIPTION
We should now take a parameter when calling `pipelined`.