### PR TITLE
Add Valkey support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.0', '3.1', '3.2', '3.3']
-        redis-version: [4, 5, 6, 7]
+        redis-version: ['4.0', '5.0', '6.0', '7.0', 'valkey-8.0']
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Start Redis
-        uses: supercharge/redis-github-action@1.4.0
+      - name: Start Redis ${{ matrix.redis-version }}
+        uses: shogo82148/actions-setup-redis@v1
         with:
           redis-version: ${{ matrix.redis-version }}
 

--- a/lib/gcra/redis_store.rb
+++ b/lib/gcra/redis_store.rb
@@ -17,7 +17,7 @@ module GCRA
     CAS_SHA = "89118e702230c0d65969c5fc557a6e942a2f4d31".freeze
     CAS_SCRIPT_MISSING_KEY_RESPONSE_PATTERN = Regexp.new('^key does not exist')
     SCRIPT_NOT_IN_CACHE_RESPONSE_PATTERN = Regexp.new(
-      '^NOSCRIPT No matching script. Please use EVAL.',
+      '^NOSCRIPT No matching script(?:\. Please use EVAL\.)?'
     )
 
     def initialize(redis, key_prefix, options = {})

--- a/lib/gcra/version.rb
+++ b/lib/gcra/version.rb
@@ -1,3 +1,3 @@
 module GCRA
-  VERSION = '1.3.0'.freeze
+  VERSION = '1.3.1'.freeze
 end


### PR DESCRIPTION
Valkey throws a different error message:

     Redis::CommandError:
       NOSCRIPT No matching script. (redis://localhost:6379)